### PR TITLE
feat(node): bump node support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14.17', '16', '18']
         os: [ubuntu-latest, windows-latest, macos-latest]
         
     runs-on: ${{ matrix.os }}
@@ -35,7 +35,7 @@ jobs:
     - name: Use Node.js 14
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '14.17'
         cache: npm
     - run: npm install -g npm@latest # Standard version seems to pull in incorrect package versions
     - run: npm ci

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Many language service plugins work perfectly in VS Code, but using them in Visua
 
 ## Compatibility
 
-* Node: >= 10.14
+* Node: >= 14.17
 * TypeScript >= 2.9
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=10.14"
+    "node": ">=14.17"
   },
   "scripts": {
     "pretest": "cd test/fixtures/workspace && npm install && cd ../../..",

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -28,7 +28,6 @@ module.exports = {
         '3.9': { version: '3.9.9', path: path.resolve(__dirname, 'workspace', 'node_modules', 'typescript39') },
         '3.0': { version: '3.0.1', path: path.resolve(__dirname, 'workspace', 'node_modules', 'typescript30') },
         '2.9': { version: '2.9.1', path: path.resolve(__dirname, 'workspace', 'node_modules', 'typescript29') },
-         // Can't go back further than 2.8 because tsserver won't work on node 10 (https://github.com/microsoft/TypeScript/commit/1fc3aebc20a13048d6595395f721c6b0078c2c08)
          // Can't go back further than 2.9 because the tsconfig warnings stop appearing
 
         // Has to be a different version to all the others for the tsversion tests


### PR DESCRIPTION
Bump minimum node support to 14.17 (matches semantic release) and include testing for node 18.

BREAKING CHANGE: Node 10 and 12 are no longer supported. 14.17+ only

Fix #42