### PR TITLE
test(deps): try harder to avoid husky prepare in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=14.17"
   },
   "scripts": {
-    "pretest": "cd test/fixtures/workspace && npm install --omit=dev && cd ../../..",
+    "pretest": "cd test/fixtures/workspace && npm install --omit=dev --ignore-scripts && cd ../../..",
     "test": "tape test/*.spec.js",
     "semantic-release": "semantic-release",
     "prepare": "husky install"


### PR DESCRIPTION
It's causing at least one failure in every set of PR builds because husky tries to install itself twice and is already in use for the second install.