### PR TITLE
ci(macos): limit test time

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,6 +30,7 @@ jobs:
     needs: test
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The tests tend to run fine on Windows or Linux in around 5 minutes. MacOS is usually slower but within ten minutes still.

Sometimes we get a dreadful run where MacOS takes hours. There's no point waiting for this, just fail early and hope we get a better machine when we run next