### PR TITLE
fix(node): drop support for node 16

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['16', '18', '20', '22']
+        node: ['18', '20', '22']
         os: [ubuntu-latest, windows-latest, macos-latest]
         
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Many language service plugins work perfectly in VS Code, but using them in Visua
 
 ## Compatibility
 
-* Node: >= 16
+* Node: >= 18
 * TypeScript >= 2.9
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "pretest": "cd test/fixtures/workspace && npm install --omit=dev --ignore-scripts && cd ../../..",


### PR DESCRIPTION
Node 16 has exceeded its maintenance period and is generating many warnings about incompatible packages during CI.

BREAKING CHANGE: Node 16.x is no longer supported

Use a supported version of node. Node 18.x or higher is supported currently.